### PR TITLE
Update to allow React 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kinde-oss/kinde-auth-react",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kinde-oss/kinde-auth-react",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@kinde-oss/kinde-auth-pkce-js": "^0.0.4"
@@ -24,8 +24,8 @@
         "rollup-plugin-terser": "^7.0.2"
       },
       "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinde-oss/kinde-auth-react",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Kinde React SDK for authentication",
   "module": "dist/kinde-auth-react.esm.min.js",
   "browser": "dist/kinde-auth-react.umd.min.js",
@@ -43,8 +43,8 @@
     "React authentication"
   ],
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
React 18 was released a few weeks ago, and I was just testing out `create-react-app` that used React 18 and it won't allow install due to unmet peer dependency.  So update to allow React 18 as a peer dependency.