### PR TITLE
Fix onRedirectCallback type signature

### DIFF
--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -24,7 +24,7 @@ type KindeProviderProps = {
   isDangerouslyUseLocalStorage?: boolean;
   logoutUri?: string;
   redirectUri: string;
-  onRedirectCallback?: (user: KindeUser, state?: State) => void;
+  onRedirectCallback?: (user: KindeUser, state?: object) => void;
   scope?: string;
 };
 export const KindeProvider = ({

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -10,7 +10,7 @@ import { initialState } from './initialState';
 import { KindeContext } from './KindeContext';
 import { reducer } from './reducer';
 import { version } from '../utils/version';
-import { KindeUser, State } from './types';
+import { KindeUser } from './types';
 
 const defaultOnRedirectCallback = () => {
   window.history.replaceState({}, document.title, window.location.pathname);

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -10,6 +10,7 @@ import { initialState } from './initialState';
 import { KindeContext } from './KindeContext';
 import { reducer } from './reducer';
 import { version } from '../utils/version';
+import { KindeUser, State } from './types';
 
 const defaultOnRedirectCallback = () => {
   window.history.replaceState({}, document.title, window.location.pathname);
@@ -23,7 +24,7 @@ type KindeProviderProps = {
   isDangerouslyUseLocalStorage?: boolean;
   logoutUri?: string;
   redirectUri: string;
-  onRedirectCallback?: () => void;
+  onRedirectCallback?: (user: KindeUser, state?: State) => void;
   scope?: string;
 };
 export const KindeProvider = ({


### PR DESCRIPTION
# Explain your changes

This changeset updates the type for `onRedirectCallback` in the KindeProviderProps.  At the moment, its signature doesn't allow for any arguments, which isn't correct; the [type in kinde-auth-pkce-js](https://github.com/kinde-oss/kinde-auth-pkce-js/blob/9c19e2c9b84cb55e71687c9698a5cb8fce44b073/index.d.ts#L25) has two arguments: `user` (mandatory KindeUser instance) and `appState` (optional state).  This just fixes the issue so anyone who might want to use the redirect callback with these arguments as [noted in the docs](https://kinde.com/docs/developer-tools/react-sdk/#handle-redirect).

Let me know if there's anything else I should do as part of contributing.  Thanks for all your work!

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
