### PR TITLE
Add getIdToken method

### DIFF
--- a/src/state/KindeContext.ts
+++ b/src/state/KindeContext.ts
@@ -18,6 +18,7 @@ export interface KindeContextProps extends State {
   getPermission: KindeClient['getPermission'];
   getOrganization: KindeClient['getOrganization'];
   getToken: KindeClient['getToken'];
+  getIdToken: KindeClient['getIdToken'];
   getUser: KindeClient['getUser'];
   getUserOrganizations: KindeClient['getUserOrganizations'];
 }

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -166,10 +166,21 @@ export const KindeProvider = ({
     return token;
   }, [client]);
 
+  const getIdToken = useCallback(async () => {
+    let idToken;
+    try {
+      idToken = await client!.getIdToken();
+    } catch (error) {
+      throw console.error(error);
+    }
+    return idToken;
+  }, [client]);
+
   const contextValue = useMemo(() => {
     return {
       ...state,
       getToken,
+      getIdToken,
       login,
       register,
       logout,
@@ -187,6 +198,7 @@ export const KindeProvider = ({
   }, [
     state,
     getToken,
+    getIdToken,
     login,
     register,
     logout,


### PR DESCRIPTION
# Explain your changes

I've raised a support thread in Discord: https://discord.com/channels/1070212618549219328/1179456563627438141

> [...]can you help me understand how to use and validate the ID Token (https://kinde.com/docs/build/about-id-tokens/) ? I'm already passing the Access Token to my REST API through the "authorization" HTTP header. However, this token doesn't contain the user's email address (https://kinde.com/docs/build/about-access-tokens/) and so on every REST API call I'm currently getting a M2M token and calling the Kinde API to get the user object to get their email address. The ID token includes the user's email address (https://kinde.com/docs/build/about-id-tokens/) but I can't see any example in your docs of the recommended way of passing this token through to a REST API and validate serverside that the ID token is valid.

This PR exposes the `getIdToken()` method which I've proposed adding in https://github.com/kinde-oss/kinde-auth-pkce-js/pull/57

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
