### PR TITLE
Use external store to manage KIndeClient instance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { useKindeAuth } from './hooks/useKindeAuth';
 export { KindeProvider } from './state/KindeProvider';
+export { getKindeStore, createKindeStore } from './state/store';

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -6,6 +6,7 @@ import createKindeClient, {
   KindeFlagValueType,
   OrgOptions
 } from '@kinde-oss/kinde-auth-pkce-js';
+import { createKindeStore, getKindeStore, subscribe } from './store';
 import React, {
   useCallback,
   useEffect,
@@ -57,9 +58,17 @@ export const KindeProvider = ({
 
   useEffect(() => {
     let isSubscribed = true;
+    const unsubscribe = subscribe(() => {
+      const kindeClient = getKindeStore();
+      setClient(kindeClient || undefined);
+    });
     try {
       const getClient = async () => {
-        const kindeClient = await createKindeClient({
+        if (client) {
+          return;
+        }
+
+        await createKindeStore({
           audience,
           scope,
           client_id: clientId,
@@ -72,7 +81,6 @@ export const KindeProvider = ({
           _framework: 'React',
           _frameworkVersion: version
         });
-        setClient(kindeClient);
       };
 
       void getClient();
@@ -81,6 +89,7 @@ export const KindeProvider = ({
     }
     return () => {
       isSubscribed = false;
+      unsubscribe();
     };
   }, [
     audience,

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -15,10 +15,10 @@ export const createKindeStore = async (options: KindeClientOptions) => {
   updatePromise = (async () => {
     try {
       authState = await createKindeClient(options);
+      listeners.forEach((listener) => listener());
     } finally {
       updatePromise = null;
     }
-    listeners.forEach((listener) => listener());
   })();
   return updatePromise;
 };

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,23 @@
+import createKindeClient, {
+  KindeClientOptions,
+  KindeClient
+} from '@kinde-oss/kinde-auth-pkce-js';
+
+let authState: KindeClient | null = null;
+
+const listeners = Array<() => void>();
+
+export const getKindeStore = () => authState;
+
+export const createKindeStore = async (options: KindeClientOptions) => {
+  authState = await createKindeClient(options);
+  listeners.forEach((listener) => listener());
+};
+
+export const subscribe = (listener: () => void) => {
+  listeners.push(listener);
+  return () => {
+    const index = listeners.indexOf(listener);
+    if (index > -1) listeners.splice(index, 1);
+  };
+};

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -4,14 +4,23 @@ import createKindeClient, {
 } from '@kinde-oss/kinde-auth-pkce-js';
 
 let authState: KindeClient | null = null;
+let updatePromise: Promise<void> | null = null;
 
 const listeners = Array<() => void>();
 
 export const getKindeStore = () => authState;
 
 export const createKindeStore = async (options: KindeClientOptions) => {
-  authState = await createKindeClient(options);
-  listeners.forEach((listener) => listener());
+  if (updatePromise) return updatePromise;
+  updatePromise = (async () => {
+    try {
+      authState = await createKindeClient(options);
+    } finally {
+      updatePromise = null;
+    }
+    listeners.forEach((listener) => listener());
+  })();
+  return updatePromise;
 };
 
 export const subscribe = (listener: () => void) => {


### PR DESCRIPTION
# Explain your changes
This is to address Issue #39  I was faced with the same issue  when using data loaders in react router (v6) and from discussions in the issue it seemed like making sure that both the hook and regular js client instance was synced was a concern. 

in this PR I think it addresses that issue by making sure that there's only one client instance and any changes will be reflected both in hooks and regular js by saving the client in an external store and using subscribers to update any reference to that client for example in hooks.

please confirm this worked. I tested only using the logout method by creating a file called auth.js in the playground and imported the `getKindeStore` function and called `logout`. This verified that the function was returning a valid client instance and since there can only be one I assume both the hooks and this logout function was using the same client.

``` js
// auth.js
import { getKindeStore } from '@kinde-oss/kinde-auth-react';

export const logout = () => {
  const kindeClient = getKindeStore();
  kindeClient.logout();
};
```

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [ x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
