### PR TITLE
fix: correct external deps in rollup config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     emptyOutDir: true,
 
     rollupOptions: {
-      external: ["react", "react-native"],
+      external: ["react", "react-native", "react/jsx-runtime", "react/jsx-dev-runtime"],
     },
   },
 


### PR DESCRIPTION
Observing build logs, the React JSX runtime was inadvertently being included in the build. This caused conflicts, specifically in all React 18 versions. They've correctly been marked as external for Rollup now.

Fixes #79 
