### PR TITLE
fix: LogoutLink redirectUrl

### DIFF
--- a/src/components/LogoutLink.tsx
+++ b/src/components/LogoutLink.tsx
@@ -7,7 +7,7 @@ export function LogoutLink({ children, ...props }: LogoutLinkProps) {
 
   const logout = useCallback(async () => {
     auth.logout({
-      redirectUrl: props.redirectUrl || window.location.origin,
+      redirectUrl: props.redirectUrl,
       allSessions: props.allSessions,
     });
   }, [auth, props.redirectUrl, props.allSessions]);


### PR DESCRIPTION
# Explain your changes

When no redirectUrl was passed to the LoginLink should use the URL given to the provider but was using window location

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
