### PR TITLE
Remove double token exchange in dev strict mode

### DIFF
--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -569,12 +569,12 @@ export const KindeProvider = ({
     if (initRef.current) return;
     try {
       try {
+        initRef.current = true;
         await checkAuth({ domain, clientId });
       } catch (err) {
         console.warn("checkAuth failed:", err);
         setState((v: ProviderState) => ({ ...v, isLoading: false }));
       }
-      initRef.current = true;
       const params = new URLSearchParams(window.location.search);
 
       if (params.has("error")) {


### PR DESCRIPTION
`initRef.current` flag was being set after an asynchronous call (`await checkAuth(...)`), both invocations of init could proceed before the flag was updated, leading to the `exchangeAuthCode` function being called twice.

# Explain your changes

The root cause of the double token exchange request appears to be the race condition within the `init` function in `KindeProvider.tsx`. React's StrictMode causes the `useEffect` that calls init to run twice. Because the `initRef.current` flag was being set after an asynchronous call (`await checkAuth(...)`), both invocations of init could proceed before the flag was updated, leading to the `exchangeAuthCode` function being called twice.

To fix this, I've moved the line `initRef.current = true;` to before the `await checkAuth({ domain, clientId });` call. This ensures that the flag is set synchronously, preventing the second invocation from executing the token exchange logic.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
