### PR TITLE
fix: only process auth flow on callback URL

### DIFF
--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -581,7 +581,8 @@ export const KindeProvider = ({
     }
 
     const hasCode = params.has("code");
-    if (!hasCode) {
+    const isOnRedirectUri = window.location.href.startsWith(redirectUri);
+    if (!hasCode || !isOnRedirectUri) {
       try {
         const user = await getUserProfile();
         if (user) {


### PR DESCRIPTION
# Explain your changes

Currently the auth flow is processed on all loads where the `code` query param exists. 

This PR will update to it will only process the code when on the callback URL

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
