### PR TITLE
fix: set initial context value to null

### DIFF
--- a/src/hooks/useKindeAuth.ts
+++ b/src/hooks/useKindeAuth.ts
@@ -4,7 +4,7 @@ import { KindeContext, KindeContextProps } from "../state/KindeContext";
 export const useKindeAuth = (): KindeContextProps => {
   const context = useContext(KindeContext);
 
-  if (context === undefined) {
+  if (context === null) {
     throw new Error("Oooops! useKindeAuth must be used within a KindeProvider");
   }
 

--- a/src/state/KindeContext.ts
+++ b/src/state/KindeContext.ts
@@ -47,6 +47,6 @@ const initialContext = {
   ...initialState,
 };
 
-export const KindeContext = createContext<KindeContextProps>(
-  initialContext as KindeContextProps,
+export const KindeContext = createContext<KindeContextProps | null>(
+  null
 );


### PR DESCRIPTION
`KindeContext` was originally populated with some initial state which was immediately overwritten in the provider.

Because of this initial state, it's difficult to tell if the hook is being used within a provider or not.