### PR TITLE
feat: add store subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   ],
   "private": false,
   "dependencies": {
-    "@kinde/js-utils": "0.25.1"
+    "@kinde/js-utils": "0.27.0"
   },
   "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
 }


### PR DESCRIPTION
Updates `KindeProvider` to add store subscription support so that it updates state (and thus it's context value) when the store is mutated in some way. Necessary for upcoming TanStack Start SDK and upcoming Next.js SDK frontend changes.