### PR TITLE
fix: check the origin of the opener before closing

### DIFF
--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -147,6 +147,16 @@ type ProviderState = {
   isLoading: boolean;
 };
 
+const isSameOriginOpener = (): boolean => {
+  try {
+    const opener = window.opener;
+    if (!opener || opener.closed) return false;
+    return opener.location.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+};
+
 type Options = { skipInitial?: boolean };
 
 const useOnLocationChange = (
@@ -239,7 +249,10 @@ export const KindeProvider = ({
             const accessToken = tokens?.accessToken;
             const refreshToken = tokens?.refreshToken;
 
-            const revokeToken = async (token: string | null | undefined, tokenTypeHint: string) => {
+            const revokeToken = async (
+              token: string | null | undefined,
+              tokenTypeHint: string,
+            ) => {
               if (!token) return;
               const response = await fetch(`${domain}/oauth2/revoke`, {
                 method: "POST",
@@ -249,7 +262,10 @@ export const KindeProvider = ({
                 },
               });
               if (!response.ok) {
-                console.warn(`Failed to revoke ${tokenTypeHint}:`, response.status);
+                console.warn(
+                  `Failed to revoke ${tokenTypeHint}:`,
+                  response.status,
+                );
               }
             };
 
@@ -746,7 +762,7 @@ export const KindeProvider = ({
         await storeState.localStorage.removeSessionItem(
           storeState.LocalKeys.performingLogout,
         );
-        if (window.opener) {
+        if (isSameOriginOpener()) {
           window.close();
         }
       }
@@ -771,7 +787,7 @@ export const KindeProvider = ({
         return;
       }
 
-      if (window.opener) {
+      if (isSameOriginOpener()) {
         const searchParams = new URLSearchParams(window.location.search);
         window.opener.postMessage(
           {
@@ -785,7 +801,7 @@ export const KindeProvider = ({
       }
       await processAuthResult(new URLSearchParams(window.location.search));
     } finally {
-      if (window.opener) {
+      if (isSameOriginOpener()) {
         window.close();
       }
     }


### PR DESCRIPTION
SDK was closing any window that opened the application, this checks the window and opener origins to ensure they match.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
