### PR TITLE
fix: add onError callback to refresh tokens for better error tracking

### DIFF
--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -706,6 +706,16 @@ export const KindeProvider = ({
       if (mergedCallbacks.onEvent) {
         mergedCallbacks.onEvent(AuthEvent.tokenRefreshed, data, contextValue);
       }
+      if (mergedCallbacks.onError) {
+        mergedCallbacks.onError(
+          {
+            error: "ERR_REFRESH_TOKEN",
+            errorDescription: data.error as string,
+          },
+          {},
+          contextValue,
+        );
+      }
     },
     [mergedCallbacks, contextValue],
   );
@@ -832,6 +842,14 @@ export const KindeProvider = ({
     ) {
       refreshToken({ domain, clientId, onRefresh }).catch((error) => {
         console.error("Error refreshing token:", error);
+        mergedCallbacks.onError?.(
+          {
+            error: "ERR_REFRESH_TOKEN",
+            errorDescription: (error as Error).message,
+          },
+          {},
+          contextValue,
+        );
       });
     }
   }, [state.isAuthenticated, domain, clientId, onRefresh, refreshOnFocus]);
@@ -859,6 +877,14 @@ export const KindeProvider = ({
         await checkAuth({ domain, clientId });
       } catch (err) {
         console.warn("checkAuth failed:", err);
+        mergedCallbacks.onError?.(
+          {
+            error: "ERR_CHECK_AUTH",
+            errorDescription: (err as Error).message,
+          },
+          {},
+          contextValue,
+        );
         setState((v: ProviderState) => ({ ...v, isLoading: false }));
       }
       const params = new URLSearchParams(window.location.search);

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -710,7 +710,8 @@ export const KindeProvider = ({
         mergedCallbacks.onError(
           {
             error: "ERR_REFRESH_TOKEN",
-            errorDescription: data.error as string,
+            errorDescription:
+              typeof data.error === "string" ? data.error : String(data.error),
           },
           {},
           contextValue,
@@ -845,7 +846,7 @@ export const KindeProvider = ({
         mergedCallbacks.onError?.(
           {
             error: "ERR_REFRESH_TOKEN",
-            errorDescription: (error as Error).message,
+            errorDescription: error instanceof Error ? error.message : String(error),
           },
           {},
           contextValue,
@@ -888,7 +889,7 @@ export const KindeProvider = ({
         mergedCallbacks.onError?.(
           {
             error: "ERR_CHECK_AUTH",
-            errorDescription: (err as Error).message,
+            errorDescription: err instanceof Error ? err.message : String(err),
           },
           {},
           contextValue,

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -706,7 +706,7 @@ export const KindeProvider = ({
       if (mergedCallbacks.onEvent) {
         mergedCallbacks.onEvent(AuthEvent.tokenRefreshed, data, contextValue);
       }
-      if (mergedCallbacks.onError) {
+      if (data.error && mergedCallbacks.onError) {
         mergedCallbacks.onError(
           {
             error: "ERR_REFRESH_TOKEN",

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -852,7 +852,15 @@ export const KindeProvider = ({
         );
       });
     }
-  }, [state.isAuthenticated, domain, clientId, onRefresh, refreshOnFocus]);
+  }, [
+    state.isAuthenticated,
+    domain,
+    clientId,
+    onRefresh,
+    refreshOnFocus,
+    mergedCallbacks,
+    contextValue,
+  ]);
 
   useEffect(() => {
     // remove any existing event listener before adding a new one


### PR DESCRIPTION
# Explain your changes

add onError callback to:
- init
- handleToken
- onRefresh

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
