### PR TITLE
fix: guard init against empty domain/clientId/redirectUri

### DIFF
--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -880,6 +880,7 @@ export const KindeProvider = ({
     if (forceChildrenRender) {
       setInitStarted(true);
     }
+    if (!domain || !clientId || !redirectUri) return;
     try {
       try {
         initRef.current = true;


### PR DESCRIPTION
# Explain your changes

Early-return from init when domain/clientId/redirectUri are empty, before initRef.current = true or checkAuth. useCallback deps already track all three, so init re-runs once real config arrives.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
