### PR TITLE
fix(KindeProvider): render children on server when forceChildrenRende…

### DIFF
--- a/src/state/KindeProvider.test.tsx
+++ b/src/state/KindeProvider.test.tsx
@@ -255,6 +255,45 @@ describe("KindeProvider", () => {
     }
   });
 
+  it("renders children in SSR output when forceChildrenRender is true", () => {
+    const prevWindow = globalThis.window;
+    vi.stubGlobal("window", undefined);
+    try {
+      const html = renderToString(
+        <KindeProvider
+          clientId="test"
+          domain="test.com"
+          redirectUri="http://localhost:3000"
+          forceChildrenRender
+        >
+          <span data-testid="ssr-child">ssr content</span>
+        </KindeProvider>,
+      );
+      expect(html).toContain("ssr content");
+    } finally {
+      vi.stubGlobal("window", prevWindow);
+    }
+  });
+
+  it("does not render children in SSR output when forceChildrenRender is false", () => {
+    const prevWindow = globalThis.window;
+    vi.stubGlobal("window", undefined);
+    try {
+      const html = renderToString(
+        <KindeProvider
+          clientId="test"
+          domain="test.com"
+          redirectUri="http://localhost:3000"
+        >
+          <span data-testid="ssr-child">ssr content</span>
+        </KindeProvider>,
+      );
+      expect(html).not.toContain("ssr content");
+    } finally {
+      vi.stubGlobal("window", prevWindow);
+    }
+  });
+
   it("does not render children while init is pending unless explicitly enabled", async () => {
     let resolveDefault: (() => void) | undefined;
     checkAuthMock.mockImplementationOnce(

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -1069,7 +1069,9 @@ export const KindeProvider = ({
     return <></>;
   }
 
-  const shouldRenderChildren = forceChildrenRender ? initStarted : initRef.current;
+  const shouldRenderChildren = forceChildrenRender
+    ? initStarted
+    : initRef.current;
 
   return shouldRenderChildren ? (
     <KindeContext.Provider value={contextValue}>

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -269,7 +269,7 @@ export const KindeProvider = ({
     isLoading: true,
   });
 
-  const [initStarted, setInitStarted] = useState(false);
+  const [initStarted, setInitStarted] = useState(forceChildrenRender);
   const contextRef = useRef<KindeContextProps | null>(null);
 
   const setLoading = useCallback(
@@ -1069,12 +1069,7 @@ export const KindeProvider = ({
     return <></>;
   }
 
-  const isServer = typeof window === "undefined";
-  const shouldRenderChildren = isServer
-    ? forceChildrenRender
-    : forceChildrenRender
-      ? initStarted
-      : initRef.current;
+  const shouldRenderChildren = forceChildrenRender ? initStarted : initRef.current;
 
   return shouldRenderChildren ? (
     <KindeContext.Provider value={contextValue}>

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -1069,9 +1069,12 @@ export const KindeProvider = ({
     return <></>;
   }
 
-  const shouldRenderChildren = forceChildrenRender
-    ? initStarted
-    : initRef.current;
+  const isServer = typeof window === "undefined";
+  const shouldRenderChildren = isServer
+    ? forceChildrenRender
+    : forceChildrenRender
+      ? initStarted
+      : initRef.current;
 
   return shouldRenderChildren ? (
     <KindeContext.Provider value={contextValue}>


### PR DESCRIPTION
# Explain your changes

`KindeProvider` gates children behind `shouldRenderChildren`, which is derived from `initStarted` or `initRef.current` — both only set inside `init()`, which runs in a `useEffect`. Since `useEffect` never runs on the server, `shouldRenderChildren` was always `false` during SSR, producing a blank render tree.

Fix: check `typeof window === "undefined"` before evaluating the flag:

```ts
const isServer = typeof window === "undefined";
const shouldRenderChildren = isServer
  ? forceChildrenRender
  : forceChildrenRender
    ? initStarted
    : initRef.current;
```

On the server, children render immediately when `forceChildrenRender` is `true`. Client-side behaviour is unchanged.

`@kinde-oss/kinde-auth-nextjs` already passes `forceChildrenRender` to this provider, so the fix restores SSR for Pages Router consumers without any changes to the Next.js SDK.

Two tests added to `KindeProvider.test.tsx` covering both branches of the server path.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
