### PR TITLE
Fix refreshToken default for custom domains

### DIFF
--- a/src/state/KindeProvider.test.tsx
+++ b/src/state/KindeProvider.test.tsx
@@ -82,7 +82,7 @@ vi.mock("@kinde/js-utils", () => {
   };
   const setInsecureStorage = () => undefined;
   const isCustomDomain = (domain: string) =>
-    !domain.match(/^(?:https?:\/\/)?[a-zA-Z0-9][.-a-zA-Z0-9]*\.kinde\.com$/i);
+    !domain.match(/^(?:https?:\/\/)?[a-zA-Z0-9][a-zA-Z0-9.-]*\.kinde\.com$/i);
 
   const base64UrlEncode = (value: string) =>
     Buffer.from(value).toString("base64url");

--- a/src/state/KindeProvider.test.tsx
+++ b/src/state/KindeProvider.test.tsx
@@ -10,7 +10,8 @@ import {
 import { renderToString } from "react-dom/server";
 import { KindeProvider } from "./KindeProvider";
 import React, { useContext } from "react";
-import { KindeContext } from "./KindeContext";
+import { KindeContext, KindeContextProps } from "./KindeContext";
+import { RefreshType } from "@kinde/js-utils";
 
 const checkAuthMock = vi.fn(() => Promise.resolve());
 const getUserProfileMock = vi.fn(() => Promise.resolve(undefined));
@@ -80,6 +81,8 @@ vi.mock("@kinde/js-utils", () => {
     activeStorage = null;
   };
   const setInsecureStorage = () => undefined;
+  const isCustomDomain = (domain: string) =>
+    !domain.match(/^(?:https?:\/\/)?[a-zA-Z0-9][.-a-zA-Z0-9]*\.kinde\.com$/i);
 
   const base64UrlEncode = (value: string) =>
     Buffer.from(value).toString("base64url");
@@ -137,6 +140,8 @@ vi.mock("@kinde/js-utils", () => {
     isAuthenticated: (...args: Parameters<typeof isAuthenticatedMock>) =>
       isAuthenticatedMock(...args),
     updateActivityTimestamp: vi.fn(),
+    isCustomDomain,
+    RefreshType: { refreshToken: 0, cookie: 1 },
     MemoryStorage,
     LocalStorage,
     setInsecureStorage,
@@ -168,6 +173,17 @@ const AuthStateConsumer = () => {
       <div data-testid="user-id">{ctx.user?.id ?? "null"}</div>
     </div>
   );
+};
+
+const ContextProbe = ({
+  onReady,
+}: {
+  onReady: (ctx: KindeContextProps) => void;
+}) => {
+  const ctx = useContext(KindeContext);
+  if (!ctx) return null;
+  onReady(ctx);
+  return null;
 };
 
 const stubWindowLocalStorage = () => ({
@@ -683,6 +699,7 @@ describe("onError on token refresh failure paths", () => {
       configurable: true,
       get: () => "visible",
     });
+
     vi.stubEnv("VITE_KINDE_REDIRECT_URL", "http://localhost:3000");
     Object.defineProperty(window, "location", {
       writable: true,
@@ -693,6 +710,118 @@ describe("onError on token refresh failure paths", () => {
         search: "",
         pathname: "/",
       },
+    });
+  });
+
+  describe("refreshToken defaults for custom domains", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      checkAuthMock.mockResolvedValue(undefined);
+      getUserProfileMock.mockResolvedValue(undefined);
+      refreshTokenMock.mockResolvedValue({ success: true });
+      Object.defineProperty(window, "location", {
+        writable: true,
+        configurable: true,
+        value: {
+          origin: "http://localhost:3000",
+          href: "http://localhost:3000",
+          search: "",
+          pathname: "/",
+        },
+      });
+    });
+
+    afterEach(async () => {
+      const { resetActiveStorage } =
+        (await import("@kinde/js-utils")) as unknown as {
+          resetActiveStorage: () => void;
+        };
+      resetActiveStorage();
+    });
+
+    it("uses cookie refresh type by default for custom domains", async () => {
+      let ctx: KindeContextProps | null = null;
+      render(
+        <KindeProvider
+          clientId="client"
+          domain="domain"
+          redirectUri="http://localhost:3000"
+        >
+          <ContextProbe onReady={(value) => (ctx = value)} />
+        </KindeProvider>,
+      );
+
+      await waitFor(() => expect(ctx).not.toBeNull());
+
+      await act(async () => {
+        await ctx!.refreshToken({
+          domain: "https://acme.example.com",
+          clientId: "client",
+        });
+      });
+
+      expect(refreshTokenMock).toHaveBeenLastCalledWith({
+        domain: "https://acme.example.com",
+        clientId: "client",
+        refreshType: RefreshType.cookie,
+      });
+    });
+
+    it("does not override explicitly provided refreshType", async () => {
+      let ctx: KindeContextProps | null = null;
+      render(
+        <KindeProvider
+          clientId="client"
+          domain="domain"
+          redirectUri="http://localhost:3000"
+        >
+          <ContextProbe onReady={(value) => (ctx = value)} />
+        </KindeProvider>,
+      );
+
+      await waitFor(() => expect(ctx).not.toBeNull());
+
+      await act(async () => {
+        await ctx!.refreshToken({
+          domain: "https://acme.example.com",
+          clientId: "client",
+          refreshType: RefreshType.refreshToken,
+        });
+      });
+
+      expect(refreshTokenMock).toHaveBeenLastCalledWith({
+        domain: "https://acme.example.com",
+        clientId: "client",
+        refreshType: RefreshType.refreshToken,
+      });
+    });
+
+    it("does not force cookie refresh when useInsecureForRefreshToken is enabled", async () => {
+      let ctx: KindeContextProps | null = null;
+      render(
+        <KindeProvider
+          clientId="client"
+          domain="domain"
+          redirectUri="http://localhost:3000"
+          useInsecureForRefreshToken
+        >
+          <ContextProbe onReady={(value) => (ctx = value)} />
+        </KindeProvider>,
+      );
+
+      await waitFor(() => expect(ctx).not.toBeNull());
+
+      await act(async () => {
+        await ctx!.refreshToken({
+          domain: "https://acme.example.com",
+          clientId: "client",
+        });
+      });
+
+      expect(refreshTokenMock).toHaveBeenLastCalledWith({
+        domain: "https://acme.example.com",
+        clientId: "client",
+      });
     });
   });
 

--- a/src/state/KindeProvider.test.tsx
+++ b/src/state/KindeProvider.test.tsx
@@ -822,6 +822,33 @@ describe("onError on token refresh failure paths", () => {
         clientId: "client",
       });
     });
+
+    it("does not force cookie refresh type for kinde.com domains", async () => {
+      let ctx: KindeContextProps | null = null;
+      render(
+        <KindeProvider
+          clientId="client"
+          domain="domain"
+          redirectUri="http://localhost:3000"
+        >
+          <ContextProbe onReady={(value) => (ctx = value)} />
+        </KindeProvider>,
+      );
+
+      await waitFor(() => expect(ctx).not.toBeNull());
+
+      await act(async () => {
+        await ctx!.refreshToken({
+          domain: "https://acme.kinde.com",
+          clientId: "client",
+        });
+      });
+
+      expect(refreshTokenMock).toHaveBeenLastCalledWith({
+        domain: "https://acme.kinde.com",
+        clientId: "client",
+      });
+    });
   });
 
   afterEach(async () => {

--- a/src/state/KindeProvider.test.tsx
+++ b/src/state/KindeProvider.test.tsx
@@ -10,7 +10,8 @@ import {
 import { renderToString } from "react-dom/server";
 import { KindeProvider } from "./KindeProvider";
 import React, { useContext } from "react";
-import { KindeContext } from "./KindeContext";
+import { KindeContext, KindeContextProps } from "./KindeContext";
+import { RefreshType } from "@kinde/js-utils";
 
 const checkAuthMock = vi.fn(() => Promise.resolve());
 const getUserProfileMock = vi.fn(() => Promise.resolve(undefined));
@@ -80,6 +81,8 @@ vi.mock("@kinde/js-utils", () => {
     activeStorage = null;
   };
   const setInsecureStorage = () => undefined;
+  const isCustomDomain = (domain: string) =>
+    !domain.match(/^(?:https?:\/\/)?[a-zA-Z0-9][.-a-zA-Z0-9]*\.kinde\.com$/i);
 
   const base64UrlEncode = (value: string) =>
     Buffer.from(value).toString("base64url");
@@ -137,6 +140,8 @@ vi.mock("@kinde/js-utils", () => {
     isAuthenticated: (...args: Parameters<typeof isAuthenticatedMock>) =>
       isAuthenticatedMock(...args),
     updateActivityTimestamp: vi.fn(),
+    isCustomDomain,
+    RefreshType: { refreshToken: 0, cookie: 1 },
     MemoryStorage,
     LocalStorage,
     setInsecureStorage,
@@ -168,6 +173,17 @@ const AuthStateConsumer = () => {
       <div data-testid="user-id">{ctx.user?.id ?? "null"}</div>
     </div>
   );
+};
+
+const ContextProbe = ({
+  onReady,
+}: {
+  onReady: (ctx: KindeContextProps) => void;
+}) => {
+  const ctx = useContext(KindeContext);
+  if (!ctx) return null;
+  onReady(ctx);
+  return null;
 };
 
 const stubWindowLocalStorage = () => ({
@@ -682,6 +698,7 @@ describe("onError on token refresh failure paths", () => {
       configurable: true,
       get: () => "visible",
     });
+
     vi.stubEnv("VITE_KINDE_REDIRECT_URL", "http://localhost:3000");
     Object.defineProperty(window, "location", {
       writable: true,
@@ -692,6 +709,118 @@ describe("onError on token refresh failure paths", () => {
         search: "",
         pathname: "/",
       },
+    });
+  });
+
+  describe("refreshToken defaults for custom domains", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      checkAuthMock.mockResolvedValue(undefined);
+      getUserProfileMock.mockResolvedValue(undefined);
+      refreshTokenMock.mockResolvedValue({ success: true });
+      Object.defineProperty(window, "location", {
+        writable: true,
+        configurable: true,
+        value: {
+          origin: "http://localhost:3000",
+          href: "http://localhost:3000",
+          search: "",
+          pathname: "/",
+        },
+      });
+    });
+
+    afterEach(async () => {
+      const { resetActiveStorage } =
+        (await import("@kinde/js-utils")) as unknown as {
+          resetActiveStorage: () => void;
+        };
+      resetActiveStorage();
+    });
+
+    it("uses cookie refresh type by default for custom domains", async () => {
+      let ctx: KindeContextProps | null = null;
+      render(
+        <KindeProvider
+          clientId="client"
+          domain="domain"
+          redirectUri="http://localhost:3000"
+        >
+          <ContextProbe onReady={(value) => (ctx = value)} />
+        </KindeProvider>,
+      );
+
+      await waitFor(() => expect(ctx).not.toBeNull());
+
+      await act(async () => {
+        await ctx!.refreshToken({
+          domain: "https://acme.example.com",
+          clientId: "client",
+        });
+      });
+
+      expect(refreshTokenMock).toHaveBeenLastCalledWith({
+        domain: "https://acme.example.com",
+        clientId: "client",
+        refreshType: RefreshType.cookie,
+      });
+    });
+
+    it("does not override explicitly provided refreshType", async () => {
+      let ctx: KindeContextProps | null = null;
+      render(
+        <KindeProvider
+          clientId="client"
+          domain="domain"
+          redirectUri="http://localhost:3000"
+        >
+          <ContextProbe onReady={(value) => (ctx = value)} />
+        </KindeProvider>,
+      );
+
+      await waitFor(() => expect(ctx).not.toBeNull());
+
+      await act(async () => {
+        await ctx!.refreshToken({
+          domain: "https://acme.example.com",
+          clientId: "client",
+          refreshType: RefreshType.refreshToken,
+        });
+      });
+
+      expect(refreshTokenMock).toHaveBeenLastCalledWith({
+        domain: "https://acme.example.com",
+        clientId: "client",
+        refreshType: RefreshType.refreshToken,
+      });
+    });
+
+    it("does not force cookie refresh when useInsecureForRefreshToken is enabled", async () => {
+      let ctx: KindeContextProps | null = null;
+      render(
+        <KindeProvider
+          clientId="client"
+          domain="domain"
+          redirectUri="http://localhost:3000"
+          useInsecureForRefreshToken
+        >
+          <ContextProbe onReady={(value) => (ctx = value)} />
+        </KindeProvider>,
+      );
+
+      await waitFor(() => expect(ctx).not.toBeNull());
+
+      await act(async () => {
+        await ctx!.refreshToken({
+          domain: "https://acme.example.com",
+          clientId: "client",
+        });
+      });
+
+      expect(refreshTokenMock).toHaveBeenLastCalledWith({
+        domain: "https://acme.example.com",
+        clientId: "client",
+      });
     });
   });
 

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -32,6 +32,8 @@ import {
   setActiveStorage,
   isAuthenticated,
   updateActivityTimestamp,
+  isCustomDomain,
+  RefreshType,
 } from "@kinde/js-utils";
 import * as storeState from "./store";
 import React, {
@@ -268,6 +270,22 @@ export const KindeProvider = ({
     isAuthenticated: false,
     isLoading: true,
   });
+
+  const refreshTokenWithProviderDefaults = useCallback(
+    (params: Parameters<typeof refreshToken>[0]) => {
+      const shouldUseCookieRefresh =
+        params.refreshType === undefined &&
+        isCustomDomain(params.domain) &&
+        !useInsecureForRefreshToken;
+
+      return refreshToken(
+        shouldUseCookieRefresh
+          ? { ...params, refreshType: RefreshType.cookie }
+          : params,
+      );
+    },
+    [useInsecureForRefreshToken],
+  );
 
   const [initStarted, setInitStarted] = useState(forceChildrenRender);
   const contextRef = useRef<KindeContextProps | null>(null);
@@ -745,12 +763,12 @@ export const KindeProvider = ({
       refreshToken: async (
         ...args: Parameters<typeof refreshToken>
       ): ReturnType<typeof refreshToken> => {
-        const result = await refreshToken(...args);
+        const result = await refreshTokenWithProviderDefaults(args[0]);
         return result;
       },
       ...state,
     };
-  }, [state, login, logout, register]);
+  }, [state, login, logout, register, refreshTokenWithProviderDefaults]);
 
   // Keep contextRef in sync with the latest contextValue
   contextRef.current = contextValue;
@@ -904,7 +922,7 @@ export const KindeProvider = ({
       // on failure, so check the resolved result here. Resolved failures are
       // surfaced through `onError` via `onRefresh`; the `.catch` only guards
       // against an unexpected thrown error.
-      refreshToken({ domain, clientId, onRefresh })
+      refreshTokenWithProviderDefaults({ domain, clientId, onRefresh })
         .then((result) => {
           if (!result.success) {
             console.error("Error refreshing token:", result.error);
@@ -928,6 +946,7 @@ export const KindeProvider = ({
     domain,
     clientId,
     onRefresh,
+    refreshTokenWithProviderDefaults,
     refreshOnFocus,
     mergedCallbacks,
     contextValue,

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -34,6 +34,8 @@ import {
   updateActivityTimestamp,
   switchOrg,
   OrgCode,
+  isCustomDomain,
+  RefreshType,
 } from "@kinde/js-utils";
 import * as storeState from "./store";
 import React, {
@@ -270,6 +272,22 @@ export const KindeProvider = ({
     isAuthenticated: false,
     isLoading: true,
   });
+
+  const refreshTokenWithProviderDefaults = useCallback(
+    (params: Parameters<typeof refreshToken>[0]) => {
+      const shouldUseCookieRefresh =
+        params.refreshType === undefined &&
+        isCustomDomain(params.domain) &&
+        !useInsecureForRefreshToken;
+
+      return refreshToken(
+        shouldUseCookieRefresh
+          ? { ...params, refreshType: RefreshType.cookie }
+          : params,
+      );
+    },
+    [useInsecureForRefreshToken],
+  );
 
   const [initStarted, setInitStarted] = useState(forceChildrenRender);
   const contextRef = useRef<KindeContextProps | null>(null);
@@ -756,12 +774,21 @@ export const KindeProvider = ({
       refreshToken: async (
         ...args: Parameters<typeof refreshToken>
       ): ReturnType<typeof refreshToken> => {
-        const result = await refreshToken(...args);
+        const result = await refreshTokenWithProviderDefaults(args[0]);
         return result;
       },
       ...state,
     };
-  }, [state, login, logout, register, domain, clientId, redirectUri]);
+  }, [
+    state,
+    login,
+    logout,
+    register,
+    domain,
+    clientId,
+    redirectUri,
+    refreshTokenWithProviderDefaults,
+  ]);
 
   // Keep contextRef in sync with the latest contextValue
   contextRef.current = contextValue;
@@ -915,7 +942,7 @@ export const KindeProvider = ({
       // on failure, so check the resolved result here. Resolved failures are
       // surfaced through `onError` via `onRefresh`; the `.catch` only guards
       // against an unexpected thrown error.
-      refreshToken({ domain, clientId, onRefresh })
+      refreshTokenWithProviderDefaults({ domain, clientId, onRefresh })
         .then((result) => {
           if (!result.success) {
             console.error("Error refreshing token:", result.error);
@@ -939,6 +966,7 @@ export const KindeProvider = ({
     domain,
     clientId,
     onRefresh,
+    refreshTokenWithProviderDefaults,
     refreshOnFocus,
     mergedCallbacks,
     contextValue,

--- a/src/state/KindeProvider.tsx
+++ b/src/state/KindeProvider.tsx
@@ -273,6 +273,13 @@ export const KindeProvider = ({
     isLoading: true,
   });
 
+  // Compat shim for a bug in @kinde/js-utils <= 0.32.0: the body-based (default)
+  // refresh always sent `credentials: "include"` on custom domains, so a stale
+  // refresh_token cookie could be sent alongside the one in the request body,
+  // causing "more than one refresh token provided". The real fix now lives in
+  // js-utils (refreshToken no longer sends credentials outside cookie mode);
+  // this default can be removed once this package depends on a version that
+  // includes it.
   const refreshTokenWithProviderDefaults = useCallback(
     (params: Parameters<typeof refreshToken>[0]) => {
       const shouldUseCookieRefresh =


### PR DESCRIPTION
## Summary
Fixes intermittent token refresh failures caused by sending both cookie credentials and a `refresh_token` body param on custom domains.

## Root cause (found during this rework)
The actual bug lives in `@kinde/js-utils`'s `refreshToken()`: it sends `credentials: "include"` for **any** refresh on a custom domain, even the default body-based flow. Since the refresh token is already in the request body in that flow, also attaching cookies lets the browser send a stale/duplicate `refresh_token` cookie alongside it, so the token endpoint sees it twice and rejects the request with `"More than one refresh token provided"`.

That's now fixed upstream: **kinde-oss/js-utils#268** (`includeCredentials = refreshType === RefreshType.cookie`).

## What changed here
- Added a provider-level refresh wrapper that defaults to `RefreshType.cookie` for custom domains when `refreshType` is not explicitly provided (and `useInsecureForRefreshToken` isn't set).
- Applied the same defaulting logic to `refreshOnFocus` refresh calls.
- Regression tests cover: cookie defaulting on custom domains, explicit `refreshType` being respected, insecure refresh-token mode not being overridden, and kinde.com domains not being affected.

## Why this PR is still needed
Even with the js-utils fix merged and released, apps on currently-published `@kinde/js-utils` versions (<= 0.32.0) are still exposed until this package bumps that dependency. This PR is a client-side compat shim for that gap - safe to keep, and can be simplified/removed once `@kinde/js-utils` is bumped past the js-utils#268 fix (see comment added in `KindeProvider.tsx`).

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm test -- --run`
- Rebased onto latest `main`