### PR TITLE
fix: extract custom props before spreading onto button element

### DIFF
--- a/src/components/PortalLink.test.tsx
+++ b/src/components/PortalLink.test.tsx
@@ -81,4 +81,22 @@ describe("ProfileLink Component", () => {
 
     consoleSpy.mockRestore();
   });
+
+  it("does not spread custom props (subNav, returnUrl) as HTML attributes on the button", async () => {
+    render(
+      <PortalLink subNav="profile" returnUrl="https://example.com/redirect">
+        Profile
+      </PortalLink>,
+    );
+
+    const button = screen.getByRole("button", { name: "Profile" });
+
+    // subNav and returnUrl are not valid HTML button attributes — they must not appear on the DOM element
+    expect(button).not.toHaveAttribute("subNav");
+    expect(button).not.toHaveAttribute("returnUrl");
+
+    // Standard HTML button attributes should still work
+    expect(button).toBeEnabled();
+  });
+
 });

--- a/src/components/PortalLink.tsx
+++ b/src/components/PortalLink.tsx
@@ -2,25 +2,30 @@ import React, { useCallback } from "react";
 import { useKindeAuth } from "../hooks/useKindeAuth";
 import { PortalLinkProps } from "../state/types";
 
-export function PortalLink({ children, ...props }: PortalLinkProps) {
+export function PortalLink({
+  children,
+  subNav,
+  returnUrl,
+  ...restProps
+}: PortalLinkProps) {
   const auth = useKindeAuth();
 
   const viewProfile = useCallback(async () => {
     try {
       const generatedUrl = await auth.generatePortalUrl({
-        subNav: props.subNav,
-        returnUrl: props.returnUrl || window.location.href,
+        subNav,
+        returnUrl: returnUrl || window.location.href,
       });
       window.location.href = generatedUrl.url.toString();
     } catch (error) {
       console.error("Failed to generate portal URL:", error);
     }
-  }, [auth, props.returnUrl, props.subNav]);
+  }, [auth, returnUrl, subNav]);
 
   return (
     <button
       type="button"
-      {...props}
+      {...restProps}
       onClick={async () => {
         await viewProfile();
       }}


### PR DESCRIPTION
## Summary

The `PortalLink` component spread all `props` (including custom attrs
`subNav` and `returnUrl`) directly onto the DOM `<button>` element,
resulting in invalid HTML attributes.

## Fix

Destructure `subNav` and `returnUrl` explicitly and spread only the
remaining valid HTML `<button>` attributes. The custom props are used
internally by the component without ever reaching the DOM.

## Changes

- `src/components/PortalLink.tsx`: destructure `children, subNav, returnUrl`,
  spread `...restProps` on the button
- `src/components/PortalLink.test.tsx`: add test asserting `subNav` and
  `returnUrl` are not present as HTML attributes on the button element

Fixes [kinde-oss/kinde-auth-react#149](https://github.com/kinde-oss/kinde-auth-react/issues/149)